### PR TITLE
Removing tests from TwitterWrapperTest.groovy

### DIFF
--- a/src/test/groovy/com/pca/TwitterWrapperTest.groovy
+++ b/src/test/groovy/com/pca/TwitterWrapperTest.groovy
@@ -18,20 +18,4 @@ class TwitterWrapperTest extends GroovyTestCase {
     void testReturnsIterableOfTweets() {
         assert getTweets().every { tweet -> tweet instanceof Tweet }
     }
-
-    void testUserAsString() {
-        assert getTweets().every { tweet -> tweet.handle instanceof String }
-    }
-
-    void testTweetAsString() {
-        assert getTweets().every { tweet -> tweet.text instanceof String }
-    }
-
-    void testNoBlankUsers() {
-        assert getTweets().every { tweet -> tweet.handle.size() > 0 }
-    }
-
-    void testNoBlankTweets() {
-        assert getTweets().every { tweet -> tweet.text.size() > 0 }
-    }
 }


### PR DESCRIPTION
Removing tests from TwitterWrapperTest.groovy that test Tweet class more than TwitterWrapper itself.
