### PR TITLE
usage of blacklist from noun to verb in processor attribute names

### DIFF
--- a/src/main/groovy/com/pca/TwitterProcessor.groovy
+++ b/src/main/groovy/com/pca/TwitterProcessor.groovy
@@ -1,19 +1,19 @@
 package com.pca
 
 class TwitterProcessor {
-    private Set<String> blackListHandles = new HashSet<String>()
-    private Set<String> blackListWords = new HashSet<String>()
-    private Set<String> whiteListHandles = new HashSet<String>()
+    private Set<String> blacklistedHandles = new HashSet<String>()
+    private Set<String> blacklistedWords = new HashSet<String>()
+    private Set<String> whitelistedHandles = new HashSet<String>()
 
-    void addBlackListHandle(String handle) {}
-    void addBlackListWord(String word) {}
-    void addWhiteListHandle(String handle) {}
+    void blacklistHandle(String handle) {}
+    void blacklistWord(String word) {}
+    void whitelistHandle(String handle) {}
 
-    void removeBlackListHandle(String handle) {}
-    void removeBlackListWord(String word) {}
-    void removeWhiteListHandle(String handle) {}
+    void unblacklistHandle(String handle) {}
+    void unblacklistWord(String word) {}
+    void unwhitelistHandle(String handle) {}
 
-    private void setBlackListHandles(Set<String> blackListHandles) {}
-    private void setBlackListWords(Set<String> blackListWords) {}
-    private void setWhiteListHandles(Set<String> whiteListHandles) {}
+    private void setBlacklistedHandles(Set<String> blacklistedHandles) {}
+    private void setBlacklistedWords(Set<String> blacklistedWords) {}
+    private void setWhitelistedHandles(Set<String> whitelistedHandles) {}
 }


### PR DESCRIPTION
Suggested attribute renaming to use blacklist and whitelist as verbs, obviating need for add & remove prefixes, shortening most function names, and lower-casing the final L in blacklist and whitelist.
